### PR TITLE
Optimistic locking

### DIFF
--- a/ClickCafeAPI/Controllers/CafesController.cs
+++ b/ClickCafeAPI/Controllers/CafesController.cs
@@ -28,7 +28,7 @@ namespace ClickCafeAPI.Controllers
         {
             // loadinas visos
             var cafes = await _db.Cafes
-                .Include(c => c.MenuItems)    // turi menuitems tai parodom
+                .Include(c => c.MenuItems)    
                 .ToListAsync();
 
             //  Map each Cafe entity to a CafeDto
@@ -40,6 +40,7 @@ namespace ClickCafeAPI.Controllers
                 PhoneNumber = c.PhoneNumber,
                 OperatingHours = c.OperatingHours,
                 Image = c.Image,
+                RowVersion = c.RowVersion,
                 MenuItemIds = c.MenuItems.Select(mi => mi.MenuItemId)
             });
 
@@ -66,6 +67,7 @@ namespace ClickCafeAPI.Controllers
                 PhoneNumber = c.PhoneNumber,
                 OperatingHours = c.OperatingHours,
                 Image = c.Image,
+                RowVersion = c.RowVersion,
                 MenuItemIds = c.MenuItems.Select(mi => mi.MenuItemId)
             };
             return Ok(dto);
@@ -109,6 +111,7 @@ namespace ClickCafeAPI.Controllers
                 PhoneNumber = cafe.PhoneNumber,
                 OperatingHours = cafe.OperatingHours,
                 Image = cafe.Image,
+                RowVersion = cafe.RowVersion,
                 MenuItemIds = new List<int>()
             };
 

--- a/ClickCafeAPI/Controllers/MenuItemsController.cs
+++ b/ClickCafeAPI/Controllers/MenuItemsController.cs
@@ -56,6 +56,7 @@ namespace ClickCafeAPI.Controllers
                 BasePrice = mi.BasePrice,
                 Category = mi.Category,
                 Image = mi.Image,
+                RowVersion = mi.RowVersion,
                 AvailableCustomizationIds = mi.AvailableCustomizations.Select(c => c.CustomizationId)
             });
 
@@ -82,6 +83,7 @@ namespace ClickCafeAPI.Controllers
                 BasePrice = menuItem.BasePrice,
                 Category = menuItem.Category,
                 Image = menuItem.Image,
+                RowVersion = menuItem.RowVersion,
                 AvailableCustomizationIds = menuItem.AvailableCustomizations.Select(c => c.CustomizationId)
             };
 
@@ -138,6 +140,7 @@ namespace ClickCafeAPI.Controllers
                 BasePrice = menuItem.BasePrice,
                 Category = menuItem.Category,
                 Image = menuItem.Image,
+                RowVersion = menuItem.RowVersion,
                 AvailableCustomizationIds = customizations.Select(c => c.CustomizationId)
             };
 

--- a/ClickCafeAPI/DTOs/CafeDTOs/CafeDto.cs
+++ b/ClickCafeAPI/DTOs/CafeDTOs/CafeDto.cs
@@ -9,5 +9,6 @@
         public string OperatingHours { get; set; } = null!;
         public string? Image { get; set; }
         public IEnumerable<int> MenuItemIds { get; set; } = new List<int>();
+        public byte[] RowVersion { get; set; } = null!;
     }
 }

--- a/ClickCafeAPI/DTOs/CafeDTOs/UpdateCafeDto.cs
+++ b/ClickCafeAPI/DTOs/CafeDTOs/UpdateCafeDto.cs
@@ -7,5 +7,6 @@
         public string PhoneNumber { get; set; }
         public string OperatingHours { get; set; }
         public string? Image { get; set; }
+        public byte[] RowVersion { get; set; } = null!;
     }
 }

--- a/ClickCafeAPI/DTOs/MenuDTOs/MenuItemDto.cs
+++ b/ClickCafeAPI/DTOs/MenuDTOs/MenuItemDto.cs
@@ -12,5 +12,6 @@ namespace ClickCafeAPI.DTOs.MenuDTOs
         public MenuItemCategory Category { get; set; }
         public string? Image { get; set; }
         public IEnumerable<int> AvailableCustomizationIds { get; set; } = new List<int>();
+        public byte[] RowVersion { get; set; } = null!;
     }
 }

--- a/ClickCafeAPI/DTOs/MenuDTOs/UpdateMenuItemDto.cs
+++ b/ClickCafeAPI/DTOs/MenuDTOs/UpdateMenuItemDto.cs
@@ -16,5 +16,6 @@ namespace ClickCafeAPI.DTOs.MenuDTOs
 
         [FromForm(Name = "AvailableCustomizationIds")]
         public List<int> AvailableCustomizationIds { get; set; } = new();
+        public byte[] RowVersion { get; set; } = null!;
     }
 }

--- a/ClickCafeAPI/Models/CafeModels/Cafe.cs
+++ b/ClickCafeAPI/Models/CafeModels/Cafe.cs
@@ -16,5 +16,7 @@ namespace ClickCafeAPI.Models.CafeModels
         public string OperatingHours { get; set; }
         public string? Image { get; set; }
         public ICollection<MenuItem> MenuItems { get; set; }
+        [Timestamp]                      
+        public byte[] RowVersion { get; set; } = null!;
     }
 }

--- a/ClickCafeAPI/Models/MenuModels/MenuItem.cs
+++ b/ClickCafeAPI/Models/MenuModels/MenuItem.cs
@@ -21,5 +21,7 @@ namespace ClickCafeAPI.Models.MenuModels
         public ICollection<Customization> AvailableCustomizations { get; set; }
         public Cafe Cafe { get; set; }
         public ICollection<OrderItem> OrderItems { get; set; }
+        [Timestamp]
+        public byte[] RowVersion { get; set; } = null!;
     }
 }


### PR DESCRIPTION
Model changes, do not forget to add migration
Optimistic locking for menu items.
To test open the same items in two tabs, change the name for both, second will throw exception.
Two use cases: either overwrite or cancel and watch the name value update.